### PR TITLE
change class to className in layout

### DIFF
--- a/packages/starters/gatsby-blog/starter/src/components/layout.js
+++ b/packages/starters/gatsby-blog/starter/src/components/layout.js
@@ -4,7 +4,7 @@ import Navbar from "./navbar"
 
 const Layout = ({ children }) => {
   return (
-    <div class="flex min-h-screen flex-col justify-between bg-neutral-50 text-neutral-900">
+    <div className="flex min-h-screen flex-col justify-between bg-neutral-50 text-neutral-900">
       <div>
         <Navbar />
         {children}


### PR DESCRIPTION
This quick PR changes `class` to `className` in `gatsby-blog/starter/src/components/layout.js`