### PR TITLE
Update README.md

### DIFF
--- a/packages/starters/gatsby-blog/README.md
+++ b/packages/starters/gatsby-blog/README.md
@@ -18,13 +18,18 @@ yarn create strapi-starter my-project gatsby-blog
 npx create-strapi-starter my-project gatsby-blog
 ```
 
-The CLI will create a monorepo, install dependencies, and run your project automatically.
+The CLI will create a monorepo, install dependencies, and run your project automatically. However, this will fail for the first time. You will need to manually create a full access [API token](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/api-tokens.html) in Strapi. Once it's created, save it as `STRAPI_TOKEN` in your environment variables.
+
+1. Start Strapi backend alone executing `yarn develop` in `./backend`
+2. Go to Settings -> API Tokens and create a new full access token
+3. Copy `.env` file for gatsby: `cp ./frontend/.env.example ./frontend/.env.development`
+4. Adjust `STRAPI_TOKEN=...` in this file
+
+After that, you can run `yarn develop` in the project's root folder (or in `./frontend` to run the Gatsby frontend alone).
 
 The Gatsby frontend server will run here => [http://localhost:3000](http://localhost:3000)
 
 The Strapi backend server will run here => [http://localhost:1337](http://localhost:1337)
-
-You will however need to manually create a full access [API token](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/api-tokens.html) in Strapi. Once it's created, save it as `STRAPI_TOKEN` in your environment variables.
 
 ## Deploying to production
 


### PR DESCRIPTION
Extend README explaining why the first run fails, how to create the API token, how to name the .env file and where to put the token exactly.